### PR TITLE
make setStatus method public

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import { HealthCheckRequest, HealthCheckResponse } from './src/proto/health_pb';
 
 declare class GrpcHealthCheck implements IHealthServer {
 	constructor(statusMap: { [key: string]: number });
-	private setStatus(service: string, status: HealthCheckResponse.ServingStatus): void;
+	setStatus(service: string, status: HealthCheckResponse.ServingStatus): void;
 	private sendStatusResponse(
 		call: grpc.ServerWriteableStream<HealthCheckRequest>,
 		status: HealthCheckResponse.ServingStatus,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grpc-ts-health-check",
-	"version": "2.0.6",
+	"version": "2.1.0",
 	"description": "An implementation of gRPC health checks, written in typescript.",
 	"main": "src/index.js",
 	"scripts": {


### PR DESCRIPTION
The `setStatus` is private which makes it impossible to adjust the status after the fact. This PR makes it public.